### PR TITLE
Update broken import from sklearn

### DIFF
--- a/mxnet_brain_segmentation.ipynb
+++ b/mxnet_brain_segmentation.ipynb
@@ -59,7 +59,7 @@
     "import os\n",
     "from glob import glob\n",
     "import imageio\n",
-    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.model_selection import train_test_split\n",
     "import time\n",
     "import urllib\n",
     "import tarfile\n",


### PR DESCRIPTION
Cloned and tried to follow along with this notebook, but the cross_validation import has been deprecated. Updated this as per: https://stackoverflow.com/questions/30667525/importerror-no-module-named-sklearn-cross-validation
